### PR TITLE
Added support to filter issues by labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ $ ./github-stats.py
 
 == General PR's ==
 
-csmith - 1
-   ninja-points - Enhancement to GitHub script
+enhancement:
+  csmith - 1
+    ninja-points - Enhancement to GitHub script
 ```
 
 By default, the script uses a search range from March 1 of a calendar year to the present. To specify an alternate date, use the `--start-date` argument such as `--start-date=2017-09-01`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ ./github-stats.py
 
 === Statistics for GitHub Organization 'redhat-cop' ====
 
-== Enhancement PR's ==
+== General PR's ==
 
 csmith - 1
    ninja-points - Enhancement to GitHub script
@@ -61,6 +61,8 @@ csmith - 1
 By default, the script uses a search range from March 1 of a calendar year to the present. To specify an alternate date, use the `--start-date` argument such as `--start-date=2017-09-01`.
 
 To limit to a specific user, the `--username` parameter can be specified.
+
+To filter by labels, the `--labels` parameter can be specified followed by a series of comma separated labels (such as `enhancement,bugfix`). To limit the results containing a label, add a `-` at the end of the label name, such as `bugfix-` If no label parameter is specified, the _enhancement_ label is automatically applied.
 
 
 ## Trello

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ By default, the script uses a search range from March 1 of a calendar year to th
 
 To limit to a specific user, the `--username` parameter can be specified.
 
-To filter by labels, the `--labels` parameter can be specified followed by a series of comma separated labels (such as `enhancement,bugfix`). To limit the results containing a label, add a `-` at the end of the label name, such as `bugfix-` If no label parameter is specified, the _enhancement_ label is automatically applied.
+To filter by labels, the `--labels` parameter can be specified followed by a series of comma separated labels. To limit the results containing a label, add a `-` at the end of the label name, such as `bugfix-` Note: Positive and negative logic cannot be combined.
 
 
 ## Trello

--- a/github-stats.py
+++ b/github-stats.py
@@ -66,7 +66,7 @@ def get_reviews(session, url):
 
 def get_org_search_issues(session, start_date):
 
-    query = "https://api.github.com/search/issues?q=user:redhat-cop+updated:>={}+archived:false+state:closed".format(start_date.date().isoformat())
+    query = "https://api.github.com/search/issues?q=user:{}+updated:>={}+archived:false+state:closed".format(GITHUB_ORG, start_date.date().isoformat())
     return handle_pagination_items(session, query)
 
 def process_labels(labels):

--- a/github-stats.py
+++ b/github-stats.py
@@ -68,12 +68,12 @@ def get_reviews(session, url):
     return pr_request.json()
 
 def get_org_search_issues(session, start_date, labels):
-    
+
     query = "https://api.github.com/search/issues?q=user:redhat-cop+updated:>={}+archived:false+state:closed{}".format(start_date.date().isoformat(), labels)
     return handle_pagination_items(session, query)
 
 def process_labels(labels):
-    output_labels = "";
+    output_labels = " ";
 
     for label in labels:
 
@@ -81,7 +81,7 @@ def process_labels(labels):
             output_labels += "-"
             label = label[0:-1]
 
-        output_labels += " label:{0}".format(label)
+        output_labels += "label:{0} ".format(label)
 
     return output_labels
 


### PR DESCRIPTION
Added support to filter GitHub issues by labels.

Modified how results are returned to support providing a set of comma separated labels through the `--labels` parameter. If no parameter is specified, the _enhancement_ label is automatically applied. To negate a label from being returned, add a `-` to the end of the label name within the argument, such as `bugfix-`

This should fully resolve #5 