### PR TITLE
adding namespace to project name so we can identify the original cer-…

### DIFF
--- a/gitlab-stats.py
+++ b/gitlab-stats.py
@@ -78,11 +78,12 @@ def get_group_with_projects(session, server, group_name, repo_matcher):
     req_group += 1
     groups.raise_for_status()
     result = groups.json()
-
     group_projects = get_projects_for_group(session, server, result["id"])
 
     for project in reversed(group_projects):
-        regex_filter_out = re.match(repo_matcher, project["name"]) == None
+        regex_filter_out = re.match(repo_matcher, project["path_with_namespace"]) == None
+        if not regex_filter_out and is_debug:
+            print "DEBUG:: Including group - {0}".format(project["path_with_namespace"])
         if regex_filter_out:
             group_projects.remove(project)
 


### PR DESCRIPTION
…template vs all the repo forks

basically the script looks at each repo name and matches a RE to check if it should be checked for points.
The problem is that if we just look at the repo name and not the entire namespace, then we cannot tell the difference between the original repo and all the forks - ie:
original/cer-template
personx/cer-template
persony/cer-template
customer1/cer-template

and there are a LOT of forks that we should not be applying points to.

this will have a small knock-on effect in the config of the ninja-board but we can fix that along-side the update to this script
