### PR TITLE
Fix gitlab stats

### DIFF
--- a/gitlab-stats.py
+++ b/gitlab-stats.py
@@ -116,7 +116,7 @@ def get_group_project_data(data_type, session, group, start_date):
         else:
             query_state = ""
 
-        query_date = "&created_after={0}".format(start_date.strftime("%Y-%m-%d"))
+        query_date = "&updated_after={0}".format(start_date.strftime("%Y-%m-%d"))
 
         query_string = "?scope=all&per_page=1000{0}{1}".format(query_state, query_date)
 
@@ -173,17 +173,16 @@ if group is None:
 group_merge_requests = get_group_project_data('merge_requests', session, group, start_date)
 
 for mr in group_merge_requests:
-    # Skip items that do not have a valid updated_at datetime
-    if dateutil.parser.parse(mr["updated_at"]) < start_date:
-        if is_debug:
-            print "DEBUG:: Omit {0} MR {1} {2}/{3}".format(mr["state"], mr["updated_at"], mr['id'], mr['title'])
-        continue
-    if is_debug:
-        print "DEBUG:: Incl {0} MR {1} {2}/{3}".format(mr["state"], mr["updated_at"], mr['id'], mr['title'])
-
-    # Check if MR has been merged
+    # Skip items that do not have a valid merged_at datetime
     if not mr['merged_at']:
         continue
+
+    if dateutil.parser.parse(mr["merged_at"]) < start_date:
+        if is_debug:
+            print "DEBUG:: Omit {0} MR {1} {2}/{3}".format(mr["state"], mr["merged_at"], mr['id'], mr['title'])
+        continue
+    if is_debug:
+        print "DEBUG:: Incl {0} MR {1} {2}/{3}".format(mr["state"], mr["merged_at"], mr['id'], mr['title'])
 
     # Filter out unwanted mr users (if username is specified, then we're only interested in MRs that have that user either the author or merger)
     if username is not None and (mr["author"]["username"] != username or mr["merged_by"]["username"] != username):
@@ -214,12 +213,16 @@ for mr in group_merge_requests:
 group_issues = get_group_project_data('issues', session, group, start_date)
 
 for iss in group_issues:
-    if dateutil.parser.parse(iss["updated_at"]) < start_date:
+    # Skip items that do not have a valid merged_at datetime
+    if not iss['closed_at']:
+        continue
+
+    if dateutil.parser.parse(iss["closed_at"]) < start_date:
         if is_debug:
-            print "DEBUG:: Omit {0} Issue {1} {2}/{3} (shortId={4})".format(iss["state"], iss["updated_at"], iss['id'], iss['title'], iss['iid'])
+            print "DEBUG:: Omit {0} Issue {1} {2}/{3} (shortId={4})".format(iss["state"], iss["closed_at"], iss['id'], iss['title'], iss['iid'])
         continue
     if is_debug:
-        print "DEBUG:: Incl {0} Issue {1} {2}/{3} (shortId={4})".format(iss["state"], iss["updated_at"], iss['id'], iss['title'], iss['iid'])
+        print "DEBUG:: Incl {0} Issue {1} {2}/{3} (shortId={4})".format(iss["state"], iss["closed_at"], iss['id'], iss['title'], iss['iid'])
 
     # Filter out if closed_by == author
     if iss["author"]["username"] == iss["closed_by"]["username"]:

--- a/gitlab-stats.py
+++ b/gitlab-stats.py
@@ -125,7 +125,7 @@ parser = argparse.ArgumentParser(description='Gather GitLab Statistics.')
 parser.add_argument("-s", "--start-date", help="The start date to query from", type=valid_date)
 parser.add_argument("-u", "--username", help="Username to query")
 parser.add_argument("-l", "--labels", help="Comma separated list to display. Add '-' at end of each label to negate")
-parser.add_argument("-r", "--human-readable", help="Human readable display")
+parser.add_argument("-r", "--human-readable", action="store_true", help="Human readable display")
 parser.add_argument("-o", "--organization", help="Organization name", default=GITLAB_GROUP_DEFAULT)
 parser.add_argument("-m", "--repo-matcher", help="Repo Matcher", default=".+")
 #parser.add_argument("-x","--repo-excluder", help="Repo Excluder")
@@ -134,7 +134,7 @@ args = parser.parse_args()
 start_date = args.start_date
 username = args.username
 input_labels = args.labels
-human_readable = args.human_readable is not None
+human_readable=(args.human_readable==True)
 gitlab_group = args.organization
 repo_matcher = args.repo_matcher
 #repo_excluder = args.repo_excluder

--- a/gitlab-stats.py
+++ b/gitlab-stats.py
@@ -25,8 +25,6 @@ closed_issues = {}
 reviewed_mrs = {}
 project_cache = {}
 
-req_group = 0
-req_pagination = 0
 is_debug = False
 
 
@@ -60,8 +58,6 @@ def handle_pagination_items(session, url):
         print "DEBUG:: handle_pagination_items(): url = {0}".format(url)
     pagination_request = session.get(url)
     pagination_request.raise_for_status()
-    global req_pagination
-    req_pagination += 1
 
     if 'next' in pagination_request.headers["Link"] and pagination_request.links['next']:
         return pagination_request.json() + handle_pagination_items(session, pagination_request.links['next']['url'])
@@ -71,8 +67,6 @@ def handle_pagination_items(session, url):
 def get_group(session, server, group_name):
     group = session.get("{0}/api/v4/groups/{1}".format(server, urllib.quote(group_name, safe='')))
     global req_group
-    req_group += 1
-    group.raise_for_status()
     result = group.json()
 
     if is_debug:
@@ -151,7 +145,6 @@ parser.add_argument("-l", "--labels", help="Comma separated list to display. Add
 parser.add_argument("-r", "--human-readable", action="store_true", help="Human readable display")
 parser.add_argument("-o", "--organization", help="Organization name", default=GITLAB_GROUP_DEFAULT)
 parser.add_argument("-m", "--repo-matcher", help="Repo Matcher", default=".+")
-#parser.add_argument("-x","--repo-excluder", help="Repo Excluder")
 args = parser.parse_args()
 
 start_date = args.start_date
@@ -160,8 +153,6 @@ input_labels = args.labels
 human_readable=(args.human_readable==True)
 gitlab_group = args.organization
 repo_matcher = re.compile(args.repo_matcher)
-#repo_excluder = args.repo_excluder
-repo_excluder = None  # this has been broken for now due to method "get_group_with_projects" but isn't used anyway
 
 if start_date is None:
     start_date = generate_start_date()


### PR DESCRIPTION
Fixes:

- Filtering of merge requests and issues (before subgroup filtering wasn't getting all of the merge_requests and issues)
- Changes the query for merge_requests and issues to use the `updated_after` attribute instead of `created_after`. This allows giving points for MRs and issues where the created date is earlier than the start date and the MR/Issue was merged/closed after the start date.
- Fix the human readable output format option

Fixes: #45 #53 #54 #55